### PR TITLE
Fix for menu overlay appearing on launch

### DIFF
--- a/style.css
+++ b/style.css
@@ -471,8 +471,8 @@ button:focus {
 	position: fixed;
 	right: 0;
 	text-align: center;
-	top: 0;
-	visibility: hidden;
+    top: 0;
+    display: none;
     -webkit-transition: all 0.5s;
     -o-transition: all 0.5s;
     transition: all 0.5s;
@@ -481,14 +481,14 @@ button:focus {
 }
 
 .mu-menu-full-overlay-show {
-	visibility: visible;
+    display: inline;
 }
 
 .mu-menu-full-overlay-inner {
 	display: inline;
 	float: left;
 	padding: 12% 15%;	
-	width: 100%;
+    width: 100%;
 }
 
 .mu-menu ul li {


### PR DESCRIPTION
Swapping visibility with display for menu overlay so that it will work with transitions